### PR TITLE
Add new blog entry: Infrastructure as Code Made Easy: A Beginner’s Guide to Terraform CDK

### DIFF
--- a/website/content/english/blogs/2023-07-19-infrastructure-as-code-made-easy-terraform-cdk.md
+++ b/website/content/english/blogs/2023-07-19-infrastructure-as-code-made-easy-terraform-cdk.md
@@ -1,0 +1,15 @@
+---
+title: "Infrastructure as Code Made Easy: A Beginner’s Guide to Terraform CDK"
+date: 2023-07-19
+draft: false
+categories: ["DevOps"]
+tags: ["Terraform", "CDKTF", "IaC"]
+images:
+  - https://earthly.dev/blog/generated/assets/images/IaC-terraform-cdk/header-800-167599356.jpg
+---
+
+> Original Article: [Infrastructure as Code Made Easy: A Beginner’s Guide to Terraform CDK](https://earthly.dev/blog/iac-terraform-cdk/)
+
+## Summary
+
+This article is a beginner’s guide to **Terraform CDK (CDKTF)**, an alternative to HashiCorp Configuration Language (HCL) that allows you to define infrastructure as code (IaC) using your favorite programming language. It covers the basics of CDKTF, its core components, and how to deploy a small Amazon Web Services (AWS) stack using TypeScript. The article explains why **CDKTF** is needed, detailing its advantages over HCL when building reusable modules and manipulating data. It guides you through setting up your local environment with the necessary prerequisites like Terraform, CDKTF CLI, Node.js, a Terraform Cloud account, and an AWS Free Tier account. You'll also learn how to create a new CDKTF project, configure providers (AWS and GitHub), create resources using CDK, modify and delete resources, and use variables and conditions in CDKTF. The article concludes with best practices for CDKTF, including creating a clear and logical structure and incorporating testing and continuous integration. This includes instructions for installing providers, creating an EC2 instance, and setting up GitHub Actions variables. It also teaches how to modify resources by adding tags and cleaning up by destroying the created resources. The guide provides examples of fetching variables using both Terraform and programming language methods, offering flexibility in configuration management. You will learn to use your language’s testing framework and CDKTF's assertion library to test the synth process.

--- a/website/content/english/blogs/2023-07-19-infrastructure-as-code-made-easy-terraform-cdk.md
+++ b/website/content/english/blogs/2023-07-19-infrastructure-as-code-made-easy-terraform-cdk.md
@@ -3,7 +3,7 @@ title: "Infrastructure as Code Made Easy: A Beginner’s Guide to Terraform CDK"
 date: 2023-07-19
 draft: false
 categories: ["DevOps"]
-tags: ["Terraform", "CDKTF", "IaC"]
+tags: ["Terraform", "IaC"]
 images:
   - https://earthly.dev/blog/generated/assets/images/IaC-terraform-cdk/header-800-167599356.jpg
 ---
@@ -12,4 +12,12 @@ images:
 
 ## Summary
 
-This article is a beginner’s guide to **Terraform CDK (CDKTF)**, an alternative to HashiCorp Configuration Language (HCL) that allows you to define infrastructure as code (IaC) using your favorite programming language. It covers the basics of CDKTF, its core components, and how to deploy a small Amazon Web Services (AWS) stack using TypeScript. The article explains why **CDKTF** is needed, detailing its advantages over HCL when building reusable modules and manipulating data. It guides you through setting up your local environment with the necessary prerequisites like Terraform, CDKTF CLI, Node.js, a Terraform Cloud account, and an AWS Free Tier account. You'll also learn how to create a new CDKTF project, configure providers (AWS and GitHub), create resources using CDK, modify and delete resources, and use variables and conditions in CDKTF. The article concludes with best practices for CDKTF, including creating a clear and logical structure and incorporating testing and continuous integration. This includes instructions for installing providers, creating an EC2 instance, and setting up GitHub Actions variables. It also teaches how to modify resources by adding tags and cleaning up by destroying the created resources. The guide provides examples of fetching variables using both Terraform and programming language methods, offering flexibility in configuration management. You will learn to use your language’s testing framework and CDKTF's assertion library to test the synth process.
+This article is a beginner’s guide to **Terraform CDK (CDKTF)**, an alternative to HashiCorp Configuration Language (HCL) that allows you to define infrastructure as code (IaC) using your favorite programming language.
+
+ I cover the basics of CDKTF, its core components, and how to deploy a small Amazon Web Services (AWS) stack using TypeScript. 
+ 
+ * You will review the advantages of using Kubernetes over HCL when building reusable modules and manipulating data. 
+ * Set up your local environment with the prerequisites like Terraform, CDKTF CLI, Node.js, a Terraform Cloud account, and an AWS Free Tier account.
+ * Learn how to create a new CDKTF project, configure providers (AWS and GitHub), create resources using CDK, modify and delete resources, and use variables and conditions in CDKTF. 
+ * Learn about best practices for CDKTF, including creating a clear and logical structure and incorporating testing and continuous integration. 
+ * Test the' synth' process using a testing framework and CDKTF's assertion library.


### PR DESCRIPTION
This pull request adds a new blog entry: Infrastructure as Code Made Easy: A Beginner’s Guide to Terraform CDK