### PR TITLE
Add: Top 7 Platform Engineering Tools blog post

### DIFF
--- a/website/content/english/blogs/2024-04-02-top-7-platform-engineering-tools.md
+++ b/website/content/english/blogs/2024-04-02-top-7-platform-engineering-tools.md
@@ -3,7 +3,7 @@ title: "Top 7 Platform Engineering Tools"
 images:
   - "https://earthly.dev/blog/generated/assets/images/platform-engineering-tools/header-800-90b901a97.jpg"
 date: 2024-04-02
-tags: ["Platform Engineering", "DevOps", "Tools", "Backstage", "Terraform", "Kubernetes", "Prometheus", "Logstash", "Jaeger", "SigNoz"]
+tags: ["Platform Engineering", "DevOps", "Backstage", "Terraform", "Kubernetes", "Prometheus", "Logstash", "Jaeger", "SigNoz"]
 categories: ["Platform Engineering"]
 draft: false
 ---

--- a/website/content/english/blogs/2024-04-02-top-7-platform-engineering-tools.md
+++ b/website/content/english/blogs/2024-04-02-top-7-platform-engineering-tools.md
@@ -1,0 +1,38 @@
+---
+title: "Top 7 Platform Engineering Tools"
+images:
+  - "https://earthly.dev/blog/generated/assets/images/platform-engineering-tools/header-800-90b901a97.jpg"
+date: 2024-04-02
+tags: ["Platform Engineering", "DevOps", "Tools", "Backstage", "Terraform", "Kubernetes", "Prometheus", "Logstash", "Jaeger", "SigNoz"]
+categories: ["Platform Engineering"]
+draft: false
+---
+
+> Original Article: [Top 7 Platform Engineering Tools](https://earthly.dev/blog/platform-engineering-tools/)
+
+## Summary
+
+This article provides an insightful overview of the **top 7 platform engineering tools** that significantly enhance **developer productivity** and streamline the software development lifecycle. It delves into the functionalities, pros, and cons of each tool, including **Backstage** for building **developer portals** and managing a **software catalog** with **self-service IDP** capabilities; **Terraform** for **infrastructure as code (IaC)** and **provisioning cloud infrastructure** using **HCL**; **Kubernetes** as the leading **container orchestration** system for **automating software deployment**, **scaling**, and **management**; **Prometheus** for robust **systems monitoring** and **alerting** through its **time series database** for **metrics**; **Logstash**, a versatile **data processing pipeline** for handling **logs** and **events** and integrating with tools like **Elasticsearch**; **Jaeger** for **distributed tracing** in **microservices** to identify **performance bottlenecks**; and finally, **SigNoz**, an **APM** and **observability platform** that unifies **traces**, **metrics**, and **logs** using **OpenTelemetry**. You will gain valuable knowledge on how these tools standardize tooling, automate processes, and implement best practices for efficient application development, deployment, and operations.
+
+## Key Concepts
+
+*   **Platform Engineering**: Focuses on improving overall developer productivity through standardized tooling, automation, and best practices.
+*   **Internal Development Platform (IDP)**: A shared infrastructure and platform that software teams use to develop, deploy, and operate applications.
+*   **Backstage**: An open-source platform by Spotify for building developer portals, acting as a software catalog and enabling self-service IDP through software templates.
+*   **Terraform**: An open-source Infrastructure as Code (IaC) tool from HashiCorp that uses HCL to provision cloud infrastructure, managing state and dependencies.
+*   **Kubernetes**: The de facto open-source container orchestration system for automating the deployment, scaling, and management of containerized applications using declarative configurations (YAML).
+*   **Prometheus**: An open-source systems monitoring and alerting toolkit with a time series database for pulling and storing application metrics, often used with Grafana and Alertmanager.
+*   **Logstash**: An open-source data processing pipeline for ingesting, transforming, and sending logs and events to various stashes like Elasticsearch, improving query performance and reducing storage costs.
+*   **Jaeger**: An open-source distributed tracing system developed by Uber for monitoring and troubleshooting microservices-based distributed systems, helping identify performance bottlenecks.
+*   **SigNoz**: An open-source Application Performance Monitoring (APM) and observability platform that uses the OpenTelemetry standard to collect and unify traces, metrics, and logs, stored in ClickHouse for high performance.
+
+## Images
+
+*   [Platform Engineering and Tooling](https://earthly.dev/blog/assets/images/platform-engineering-tools/j3837Ob.png)
+*   [Backstage](https://earthly.dev/blog/assets/images/platform-engineering-tools/backstage.png)
+*   [Terraform](https://earthly.dev/blog/assets/images/platform-engineering-tools/terraform.png)
+*   [Kubernetes](https://earthly.dev/blog/assets/images/platform-engineering-tools/kubernetes.png)
+*   [Prometheus](https://earthly.dev/blog/assets/images/platform-engineering-tools/prometheus.png)
+*   [Logstash](https://earthly.dev/blog/assets/images/platform-engineering-tools/logstash.png)
+*   [Jaeger](https://earthly.dev/blog/assets/images/platform-engineering-tools/jaeger.png)
+*   [SigNoz](https://earthly.dev/blog/assets/images/platform-engineering-tools/signoz.png)


### PR DESCRIPTION
This pull request adds a new blog post titled 'Top 7 Platform Engineering Tools' summarizing the key aspects of various platform engineering tools, including Backstage, Terraform, Kubernetes, Prometheus, Logstash, Jaeger, and SigNoz. It highlights their roles in improving developer productivity and streamlining the software development lifecycle.