### PR TITLE
New Blog Post: Choosing the right DevOps training

### DIFF
--- a/website/content/english/blogs/2022-03-28-choosing-the-right-devops-training.md
+++ b/website/content/english/blogs/2022-03-28-choosing-the-right-devops-training.md
@@ -1,0 +1,33 @@
+---
+title: "Choosing the right DevOps training | GOLOGIC"
+date: 2022-03-28
+draft: false
+categories: ["DevOps", "Training"]
+tags: ["DevOps", "Training", "Certifications", "Learning", "Career"]
+images:
+  - https://www.gologic.ca/wp-content/uploads/2022/03/Tendances_Recommandations_Parcours_DevOps_20222.png
+---
+
+[Original Article](https://www.gologic.ca/en/choosing-the-right-devops-training/)
+
+## Summary
+
+The article "Choosing the right DevOps training" emphasizes the crucial need for IT professionals to stay updated in the rapidly evolving DevOps landscape. It guides you through a structured approach to choosing the most suitable **DevOps training** based on your current knowledge and career aspirations.
+
+To begin your journey, I recommend focusing on foundational knowledge. Reading key books like **The DevOps Handbook**, **The Unicorn Project**, and **Accelerate** by Gene Kim and Jez Humble will provide you with a solid understanding of DevOps principles, including its four pillars: **Culture, Automation, Measurement, and Sharing**. If you prefer a structured learning environment, the **DevOps Foundation®** certification from the DevOps Institute is an excellent starting point.
+
+Next, you should strengthen your core DevOps practices. This includes mastering **Continuous Integration, Continuous Delivery, and Continuous Deployment** (CI/CD pipelines), along with **Automation and Pipeline as Code**. Developing skills in **Monitoring and Retroaction**, often aligned with the **SRE model**, is also crucial for effective troubleshooting in production. Cloud provider certifications from AWS, GCP, or Azure can help solidify these foundational skills.
+
+Finally, to become a **DevOps expert**, the article suggests specializing in a specific role, using resources like [roadmap.sh](https://roadmap.sh) for guidance. Continuous learning through online classes on platforms like [LinkedIn Learning](https://www.linkedin.com/learning/) and [Udemy](https://www.udemy.com/), and by reading blog posts from sources such as [draft.dev](https://draft.dev), [Medium](https://medium.com/), and [The New Stack](https://thenewstack.io/), is highly recommended for acquiring new technical skills and tools. For specialized expertise, pursuing advanced certifications, especially in **Kubernetes** like the **Certified Kubernetes Application Developer (CKAD)** or **Certified Kubernetes Administrator (CKA)**, will significantly enhance your profile.
+
+In conclusion, I believe that choosing the right DevOps training involves a strategic plan centered on foundational knowledge, core practices, and continuous personal development to achieve specialized expertise and stay ahead in this dynamic field.
+
+## References
+
+*   [roadmap.sh](https://roadmap.sh)
+*   [draft.dev](https://draft.dev)
+*   [Medium](https://medium.com/)
+*   [The New Stack](https://thenewstack.io/)
+*   [Google Cloud’s Blog](https://cloud.google.com/blog/topics/sre)
+*   [LinkedIn Learning](https://www.linkedin.com/learning/)
+*   [Udemy](https://www.udemy.com/)


### PR DESCRIPTION
This pull request adds a new blog entry titled "Choosing the right DevOps training". The article summarizes key aspects of DevOps training, including foundational knowledge, core practices, and specialization paths. It also includes relevant references and follows the specified Markdown formatting guidelines.