### PR TITLE
feat: Add "The DevOps Paradox: a Shift Away from Ops" Blog Post

### DIFF
--- a/website/content/english/blogs/2023-05-18-the-devops-paradox-a-shift-away-from-ops.md
+++ b/website/content/english/blogs/2023-05-18-the-devops-paradox-a-shift-away-from-ops.md
@@ -1,0 +1,14 @@
+---
+title: "The DevOps Paradox: a Shift Away from Ops"
+date: "2023-05-18"
+description: "A short story about DevOps evolution — DevOps meant Dev and Ops collaboration, but they removed Ops from the equation instead"
+tags: ["DevOps", "Cloud", "Software Engineering"]
+---
+
+[Original Article](https://betterprogramming.pub/the-devops-paradox-a-shift-away-from-ops-26b3615ed97e)
+
+In my latest article, I delve into the **DevOps Paradox**, exploring its evolution from a collaborative culture between **Development (Dev)** and **Operations (Ops)** to a paradigm where Ops is increasingly sidelined. I trace this shift back to the rise of **cloud computing** and the proliferation of **as-a-Service** models (**IaaS, PaaS, SaaS**), which have largely automated and abstracted away the traditional responsibilities of Ops.
+
+This has led to the emergence of the **"DevOps engineer"**, a role that often focuses on maintaining the very tools designed to simplify software integration and deployment, effectively creating a new kind of silo. While DevOps has championed valuable principles like **"shift left"** and **"you build it, you run it,"** and has been instrumental in the widespread adoption of **Continuous Delivery**, the complexity of the modern toolchain (as illustrated by the **CNCF Landscape**) presents its own set of challenges.
+
+I also touch on the irony that while DevOps was meant to break down silos, it has paradoxically led to the removal of Ops from the equation, a trend that continues with derivatives like **DevSecOps, FinOps, and GitOps**. I invite you to read the [Original Article](https to explore this fascinating evolution and its implications for the future of software engineering.


### PR DESCRIPTION
This pull request adds a new blog post titled "The DevOps Paradox: a Shift Away from Ops".

The post explores the evolution of DevOps, from its origins in fostering collaboration between developers and operations teams to its current state, where the role of traditional Ops has been significantly diminished by cloud computing and automation. It delves into the rise of the DevOps engineer, the challenges of navigating the complex modern toolchain, and the paradoxical outcome of a movement that aimed to break down silos but has, in many ways, simply shifted them.

This summary provides a concise overview of the key points discussed in the original article, making it a valuable addition to the blog.
